### PR TITLE
Adding new convention for ports on new rest services

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Creates a basic gradle project with a simple build.gradle file.
 
 Creates a skeleton SpringBoot REST project (includes build.gradle, application class, and supporting classes)
 
+You WILL get an error when running `./gradlew bootRun`:
+* After creating your project, update application.properties `server.port` and `management.port` values following
+the convention described in the [Blackbaud Wiki](https://wiki.blackbaud.com/display/LUM/Microservice+Port+Mapping+Registry)
+
 
 ### Project Augmentation Tasks
 

--- a/src/main/resources/templates/springboot/rest/application.properties.tmpl
+++ b/src/main/resources/templates/springboot/rest/application.properties.tmpl
@@ -1,4 +1,4 @@
 spring.jersey.type=servlet
 server.servlet-path=/s
-server.port=8080
-management.port=8081
+server.port=-1
+management.port=-1


### PR DESCRIPTION
@blackbaud/constituent-service Review and merge when ready, will have other updates to bluemoon-dojo, notifications, bluemoon-core, and their respective frontends to follow this new port convention.

A new WIKI page has been created and referenced in the README.

When creating a new rest project, the first run of ./gradlew bootRun
will cause an exception since server.port and management.port are set to -1.
This was done to solve the problem of multiple backend services on developer
machines from colliding on ports.

https://jira.blackbaud.com/browse/LUM-3383
