### PR TITLE
new standard is 8 9s in default version

### DIFF
--- a/src/main/resources/templates/basic/gradle.properties.tmpl
+++ b/src/main/resources/templates/basic/gradle.properties.tmpl
@@ -1,3 +1,3 @@
 artifactId=${artifactId}
-version=0.99999
+version=0.99999999
 defaultJavaVersion=1.8


### PR DESCRIPTION
only having 5 9s breaks dependency management, especially locally

@blackbaud/micro-cervezas 

@Blackbaud-AaronHensley FYI this is what broke you
