### PR TITLE
LUM-25516 bbauth enabled out of box for vsts

### DIFF
--- a/src/main/groovy/com/blackbaud/templates/tasks/RestProject.groovy
+++ b/src/main/groovy/com/blackbaud/templates/tasks/RestProject.groovy
@@ -57,7 +57,7 @@ class RestProject {
         if (vsts) {
             File applicationProperties = basicProject.getProjectFileOrFail("src/main/resources/application.properties")
             applicationProperties << """\
-
+bbauth.enabled=true
 long.token.enabled=false
 """
         } else {


### PR DESCRIPTION
@Blackbaud-EricSlater @Blackbaud-MikeLueders @blackbaud-rachelbeale 
the build fails out of the box without this when created via the vsts tools due to bean creation failures