### PR TITLE
Remove redundant `-db` suffix

### DIFF
--- a/src/main/resources/templates/cosmos/cosmos-config.java.tmpl
+++ b/src/main/resources/templates/cosmos/cosmos-config.java.tmpl
@@ -14,7 +14,7 @@ public class CosmosConfig extends MongoCosmosConfig {
     @Value("\${spring.data.mongodb.uri}")
     private String databaseUri;
 
-    @Value("\${spring.application.name}-db")
+    @Value("\${spring.application.name}")
     private String databaseName;
 
     @Override


### PR DESCRIPTION
@Blackbaud-MikeLueders thoughts? I find the `-db` suffix redundant since it's already known it is a DB and then when you select the DB or list DBs it is just redundant marker.

ATT-2799