### PR TITLE
Disable spring cloud config for VSTS services

### DIFF
--- a/src/componentTest/resources/expectedTemplateContent/add-cosmos-auditable-entity-message/src/main/java/com/blackbaud/service/config/CosmosConfig.java
+++ b/src/componentTest/resources/expectedTemplateContent/add-cosmos-auditable-entity-message/src/main/java/com/blackbaud/service/config/CosmosConfig.java
@@ -14,7 +14,7 @@ public class CosmosConfig extends MongoCosmosConfig {
     @Value("${spring.data.mongodb.uri}")
     private String databaseUri;
 
-    @Value("${spring.application.name}-db")
+    @Value("${spring.application.name}")
     private String databaseName;
 
     @Override

--- a/src/componentTest/resources/expectedTemplateContent/add-cosmos-auditable-entity-message/src/main/resources/bootstrap.properties
+++ b/src/componentTest/resources/expectedTemplateContent/add-cosmos-auditable-entity-message/src/main/resources/bootstrap.properties
@@ -1,1 +1,2 @@
 spring.application.name=service
+spring.cloud.config.enabled=false

--- a/src/componentTest/resources/expectedTemplateContent/add-cosmos-entity-message/src/main/java/com/blackbaud/service/config/CosmosConfig.java
+++ b/src/componentTest/resources/expectedTemplateContent/add-cosmos-entity-message/src/main/java/com/blackbaud/service/config/CosmosConfig.java
@@ -14,7 +14,7 @@ public class CosmosConfig extends MongoCosmosConfig {
     @Value("${spring.data.mongodb.uri}")
     private String databaseUri;
 
-    @Value("${spring.application.name}-db")
+    @Value("${spring.application.name}")
     private String databaseName;
 
     @Override

--- a/src/componentTest/resources/expectedTemplateContent/add-cosmos-entity-message/src/main/resources/bootstrap.properties
+++ b/src/componentTest/resources/expectedTemplateContent/add-cosmos-entity-message/src/main/resources/bootstrap.properties
@@ -1,1 +1,2 @@
 spring.application.name=service
+spring.cloud.config.enabled=false

--- a/src/componentTest/resources/expectedTemplateContent/add-resource-jpa-entity/src/main/resources/bootstrap.properties
+++ b/src/componentTest/resources/expectedTemplateContent/add-resource-jpa-entity/src/main/resources/bootstrap.properties
@@ -1,1 +1,2 @@
 spring.application.name=service
+spring.cloud.config.enabled=false

--- a/src/componentTest/resources/expectedTemplateContent/add-resource-kafka-message/src/main/resources/bootstrap.properties
+++ b/src/componentTest/resources/expectedTemplateContent/add-resource-kafka-message/src/main/resources/bootstrap.properties
@@ -1,1 +1,2 @@
 spring.application.name=service
+spring.cloud.config.enabled=false

--- a/src/componentTest/resources/expectedTemplateContent/add-resource-rest-api/src/main/resources/bootstrap.properties
+++ b/src/componentTest/resources/expectedTemplateContent/add-resource-rest-api/src/main/resources/bootstrap.properties
@@ -1,1 +1,2 @@
 spring.application.name=service
+spring.cloud.config.enabled=false

--- a/src/componentTest/resources/expectedTemplateContent/deployable-with-cosmos/src/main/java/com/blackbaud/service/config/CosmosConfig.java
+++ b/src/componentTest/resources/expectedTemplateContent/deployable-with-cosmos/src/main/java/com/blackbaud/service/config/CosmosConfig.java
@@ -14,7 +14,7 @@ public class CosmosConfig extends MongoCosmosConfig {
     @Value("${spring.data.mongodb.uri}")
     private String databaseUri;
 
-    @Value("${spring.application.name}-db")
+    @Value("${spring.application.name}")
     private String databaseName;
 
     @Override

--- a/src/componentTest/resources/expectedTemplateContent/deployable-with-cosmos/src/main/resources/bootstrap.properties
+++ b/src/componentTest/resources/expectedTemplateContent/deployable-with-cosmos/src/main/resources/bootstrap.properties
@@ -1,1 +1,2 @@
 spring.application.name=service
+spring.cloud.config.enabled=false

--- a/src/componentTest/resources/expectedTemplateContent/deployable-with-kafka/src/main/resources/bootstrap.properties
+++ b/src/componentTest/resources/expectedTemplateContent/deployable-with-kafka/src/main/resources/bootstrap.properties
@@ -1,1 +1,2 @@
 spring.application.name=service
+spring.cloud.config.enabled=true

--- a/src/componentTest/resources/expectedTemplateContent/deployable-with-postgres/src/main/resources/bootstrap.properties
+++ b/src/componentTest/resources/expectedTemplateContent/deployable-with-postgres/src/main/resources/bootstrap.properties
@@ -1,1 +1,2 @@
 spring.application.name=service
+spring.cloud.config.enabled=true

--- a/src/componentTest/resources/expectedTemplateContent/deployable/src/main/resources/bootstrap.properties
+++ b/src/componentTest/resources/expectedTemplateContent/deployable/src/main/resources/bootstrap.properties
@@ -1,1 +1,2 @@
 spring.application.name=service
+spring.cloud.config.enabled=false

--- a/src/componentTest/resources/expectedTemplateContent/service-bus-consumer/src/main/resources/bootstrap.properties
+++ b/src/componentTest/resources/expectedTemplateContent/service-bus-consumer/src/main/resources/bootstrap.properties
@@ -1,1 +1,2 @@
 spring.application.name=service
+spring.cloud.config.enabled=false

--- a/src/componentTest/resources/expectedTemplateContent/service-bus-internal-topic-datasync/src/main/resources/bootstrap.properties
+++ b/src/componentTest/resources/expectedTemplateContent/service-bus-internal-topic-datasync/src/main/resources/bootstrap.properties
@@ -1,1 +1,2 @@
 spring.application.name=service
+spring.cloud.config.enabled=false

--- a/src/componentTest/resources/expectedTemplateContent/service-bus-internal-topic-scheduled/src/main/resources/bootstrap.properties
+++ b/src/componentTest/resources/expectedTemplateContent/service-bus-internal-topic-scheduled/src/main/resources/bootstrap.properties
@@ -1,1 +1,2 @@
 spring.application.name=service
+spring.cloud.config.enabled=false

--- a/src/componentTest/resources/expectedTemplateContent/service-bus-producer/src/main/resources/bootstrap.properties
+++ b/src/componentTest/resources/expectedTemplateContent/service-bus-producer/src/main/resources/bootstrap.properties
@@ -1,1 +1,2 @@
 spring.application.name=service
+spring.cloud.config.enabled=false

--- a/src/componentTest/resources/expectedTemplateContent/service-bus-sessions-enabled/src/main/resources/bootstrap.properties
+++ b/src/componentTest/resources/expectedTemplateContent/service-bus-sessions-enabled/src/main/resources/bootstrap.properties
@@ -1,1 +1,2 @@
 spring.application.name=service
+spring.cloud.config.enabled=false

--- a/src/main/groovy/com/blackbaud/templates/project/RestProject.groovy
+++ b/src/main/groovy/com/blackbaud/templates/project/RestProject.groovy
@@ -116,7 +116,8 @@ authorization.filter.enable=false
         }
 
         basicProject.applyTemplate("src/main/resources") {
-            "bootstrap.properties" template: "/templates/springboot/bootstrap.properties.tmpl", serviceId: "${serviceId}"
+            "bootstrap.properties" template: "/templates/springboot/bootstrap.properties.tmpl",
+                                   serviceId: "${serviceId}", useConfigServer: vsts ? "false" : "true"
         }
 
         if (vsts == false) {

--- a/src/main/resources/templates/springboot/bootstrap.properties.tmpl
+++ b/src/main/resources/templates/springboot/bootstrap.properties.tmpl
@@ -1,1 +1,2 @@
 spring.application.name=${serviceId}
+spring.cloud.config.enabled=${useConfigServer}


### PR DESCRIPTION
Removing bootstrap-cloud.properties is not enough to prevent "Could not locate PropertySource" error messages. Adding "spring.cloud.config.enabled=false" to bootstrap.properties for VSTS projects. 

@Blackbaud-MikeLueders 