### PR TITLE
fixed performance test template and added test

### DIFF
--- a/src/componentTest/groovy/com/blackbaud/templates/tasks/TemplateGenerationSpec.groovy
+++ b/src/componentTest/groovy/com/blackbaud/templates/tasks/TemplateGenerationSpec.groovy
@@ -5,6 +5,7 @@ import com.blackbaud.templates.project.AsyncProject
 import com.blackbaud.templates.project.BasicProject
 import com.blackbaud.templates.project.IntegrationTestProject
 import com.blackbaud.templates.project.KafkaProject
+import com.blackbaud.templates.project.PerformanceTestsProject
 import com.blackbaud.templates.project.RestProject
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -329,6 +330,18 @@ class TemplateGenerationSpec extends AbstractProjectSpecification {
 
         then:
         greenwashOrAssertExpectedContent(restProject, "add-rest-resource")
+    }
+
+    def "should create performance test submodule"() {
+        given:
+        BasicProject basicProject = initBasicProject()
+        PerformanceTestsProject performanceTestsProject = new PerformanceTestsProject(basicProject)
+
+        when:
+        performanceTestsProject.initPerformanceTests()
+
+        then:
+        greenwashOrAssertExpectedContent(basicProject, "performance-tests")
     }
 
 }

--- a/src/componentTest/resources/expectedTemplateContent/performance-tests/build.gradle
+++ b/src/componentTest/resources/expectedTemplateContent/performance-tests/build.gradle
@@ -1,0 +1,19 @@
+buildscript {
+    dependencies {
+        classpath "com.blackbaud:gradle-internal:4.+"
+    }
+}
+
+apply plugin: "blackbaud-internal"
+
+dependencies {
+    compile "com.google.guava:guava:23.6.1-jre"
+    compileOnly "org.projectlombok:lombok:1.18.2"
+
+    testCompile "com.blackbaud:common-test:4.+"
+    testCompile "org.codehaus.groovy:groovy-all:2.4.7"
+    testCompile ("org.spockframework:spock-core:1.1-groovy-2.4") {
+        exclude group: "org.codehaus.groovy"
+    }
+}
+

--- a/src/componentTest/resources/expectedTemplateContent/performance-tests/performance-tests/build.gradle
+++ b/src/componentTest/resources/expectedTemplateContent/performance-tests/performance-tests/build.gradle
@@ -1,0 +1,49 @@
+apply plugin: 'scala'
+apply plugin: 'java'
+
+sourceSets {
+    performanceTests {
+        scala {
+            srcDir 'src/main/scala'
+            include 'src/main/scala/**'
+        }
+    }
+}
+
+dependencies {
+    compile 'com.blackbaud:common-gatling:0.+'
+
+    performanceTestsCompile 'io.gatling.highcharts:gatling-charts-highcharts:2.3.1'
+    performanceTestsCompile 'com.typesafe:config:1.3.0'
+    performanceTestsCompile 'org.fluttercode.datafactory:datafactory:0.8'
+    performanceTestsCompile 'net.liftweb:lift-json-scalaz_2.10:2.6.3'
+}
+
+class GatlingPerfTest extends JavaExec {
+    String group = 'Gatling Perf Test'
+    String simulationClass = ""
+
+    public GatlingPerfTest() {
+        super()
+        classpath = project.sourceSets.main.compileClasspath + project.sourceSets.main.runtimeClasspath + project.sourceSets.performanceTests.compileClasspath
+        setMain("io.gatling.app.Gatling")
+    }
+
+    def setSimulationClass(String simClass) {
+        args(['--simulation', simClass])
+    }
+}
+
+task serviceTest (type: GatlingPerfTest) {
+    simulationClass = 'com.blackbaud.service.ServiceTest'
+}
+
+task runGatlingTests {
+    dependsOn 'serviceTest'
+}
+
+publishing_ext {
+    publication('main') {
+        enabled = false
+    }
+}

--- a/src/componentTest/resources/expectedTemplateContent/performance-tests/performance-tests/src/main/scala/com.blackbaud.service/ServiceTest.scala
+++ b/src/componentTest/resources/expectedTemplateContent/performance-tests/performance-tests/src/main/scala/com.blackbaud.service/ServiceTest.scala
@@ -1,10 +1,10 @@
-package com.blackbaud.${lowerCaseName}
+package com.blackbaud.service
 
 import io.gatling.core.Predef.{exec, forever, scenario}
 import io.gatling.http.Predef.http
 import io.gatling.core.Predef._
 
-class ${upperCamelName}Test extends Simulation {
+class ServiceTest extends Simulation {
 
   var maxTestRuntimeSec: Int = Option(System.getProperty("max.test.runtime.sec")).map(_.toInt).getOrElse(30)
   var debug = false
@@ -40,13 +40,13 @@ class ${upperCamelName}Test extends Simulation {
       group("Test Setup") {
          exec(http("requestName")
             .get("/setupUri")
-            .header("Authorization", "\${access_token}"))
+            .header("Authorization", "${access_token}"))
       }
 
       .repeat(30) {
          exec(http(requestName)
             .get("yourEndpoint")
-            .header("Authorization", "\${access_token}"))
+            .header("Authorization", "${access_token}"))
       }
     }
 

--- a/src/componentTest/resources/expectedTemplateContent/performance-tests/settings.gradle
+++ b/src/componentTest/resources/expectedTemplateContent/performance-tests/settings.gradle
@@ -1,0 +1,1 @@
+include "performance-tests"

--- a/src/main/groovy/com/blackbaud/templates/project/PerformanceTestsProject.groovy
+++ b/src/main/groovy/com/blackbaud/templates/project/PerformanceTestsProject.groovy
@@ -1,7 +1,5 @@
 package com.blackbaud.templates.project
 
-import com.blackbaud.templates.project.BasicProject;
-
 class PerformanceTestsProject {
 
     private BasicProject basicProject


### PR DESCRIPTION
@Blackbaud-KyleMartinez the `addPerformanceTest` task was exploding due to a missing variable `access_token`.  it looks like the intent was to generate the file with `$access_token` rather than having the variable interpolated on generation so that's what i made it do - but if that was not the intent, let me know.