### PR TITLE
qualify gradle project path - leaving off the : does not work if refe…

### DIFF
--- a/src/componentTest/resources/expectedTemplateContent/add-resource-kafka-message/build.gradle
+++ b/src/componentTest/resources/expectedTemplateContent/add-resource-kafka-message/build.gradle
@@ -36,11 +36,11 @@ allprojects {
 }
 
 dependencies {
-    compile project("kafka-client")
+    compile project(":kafka-client")
     compile "com.blackbaud:tokens-client:3.+"
     compile "com.blackbaud:common-spring-boot-rest:${commonSpringBootVersion}"
 
-    sharedTestCompile project(path: "kafka-client", configuration: "mainTestRuntime")
+    sharedTestCompile project(path: ":kafka-client", configuration: "mainTestRuntime")
     sharedTestCompile "com.blackbaud:common-spring-boot-rest-test:${commonSpringBootVersion}"
     sharedTestCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
     sharedTestCompile 'cglib:cglib-nodep:2.2.2'

--- a/src/componentTest/resources/expectedTemplateContent/add-resource-rest-api/build.gradle
+++ b/src/componentTest/resources/expectedTemplateContent/add-resource-rest-api/build.gradle
@@ -36,11 +36,11 @@ allprojects {
 }
 
 dependencies {
-    compile project("rest-client")
+    compile project(":rest-client")
     compile "com.blackbaud:tokens-client:3.+"
     compile "com.blackbaud:common-spring-boot-rest:${commonSpringBootVersion}"
 
-    sharedTestCompile project(path: "rest-client", configuration: "mainTestRuntime")
+    sharedTestCompile project(path: ":rest-client", configuration: "mainTestRuntime")
     sharedTestCompile "com.blackbaud:common-spring-boot-rest-test:${commonSpringBootVersion}"
     sharedTestCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
     sharedTestCompile 'cglib:cglib-nodep:2.2.2'

--- a/src/componentTest/resources/expectedTemplateContent/add-rest-resource/build.gradle
+++ b/src/componentTest/resources/expectedTemplateContent/add-rest-resource/build.gradle
@@ -36,11 +36,11 @@ allprojects {
 }
 
 dependencies {
-    compile project("rest-client")
+    compile project(":rest-client")
     compile "com.blackbaud:tokens-client:3.+"
     compile "com.blackbaud:common-spring-boot-rest:${commonSpringBootVersion}"
 
-    sharedTestCompile project(path: "rest-client", configuration: "mainTestRuntime")
+    sharedTestCompile project(path: ":rest-client", configuration: "mainTestRuntime")
     sharedTestCompile "com.blackbaud:common-spring-boot-rest-test:${commonSpringBootVersion}"
     sharedTestCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
     sharedTestCompile 'cglib:cglib-nodep:2.2.2'

--- a/src/componentTest/resources/expectedTemplateContent/eventhubs-message/build.gradle
+++ b/src/componentTest/resources/expectedTemplateContent/eventhubs-message/build.gradle
@@ -38,12 +38,12 @@ allprojects {
 }
 
 dependencies {
-    compile project("eventhubs-client")
+    compile project(":eventhubs-client")
     compile "com.blackbaud:tokens-client:3.+"
     compile "com.blackbaud:common-spring-boot-rest:${commonSpringBootVersion}"
     compile "com.blackbaud:common-async-event-hubs:${commonAsyncEventHubsVersion}"
 
-    sharedTestCompile project(path: "eventhubs-client", configuration: "mainTestRuntime")
+    sharedTestCompile project(path: ":eventhubs-client", configuration: "mainTestRuntime")
     sharedTestCompile "com.blackbaud:common-spring-boot-rest-test:${commonSpringBootVersion}"
     sharedTestCompile "com.blackbaud:common-async-event-hubs-test:${commonAsyncEventHubsVersion}"
     sharedTestCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"

--- a/src/componentTest/resources/expectedTemplateContent/service-bus-producer/build.gradle
+++ b/src/componentTest/resources/expectedTemplateContent/service-bus-producer/build.gradle
@@ -38,12 +38,12 @@ allprojects {
 }
 
 dependencies {
-    compile project("service-bus-client")
+    compile project(":service-bus-client")
     compile "com.blackbaud:tokens-client:3.+"
     compile "com.blackbaud:common-spring-boot-rest:${commonSpringBootVersion}"
     compile "com.blackbaud:common-async-service-bus:${commonAsyncServiceBusVersion}"
 
-    sharedTestCompile project(path: "service-bus-client", configuration: "mainTestRuntime")
+    sharedTestCompile project(path: ":service-bus-client", configuration: "mainTestRuntime")
     sharedTestCompile "com.blackbaud:common-spring-boot-rest-test:${commonSpringBootVersion}"
     sharedTestCompile "com.blackbaud:common-async-service-bus-test:${commonAsyncServiceBusVersion}"
     sharedTestCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"

--- a/src/main/groovy/com/blackbaud/templates/project/BasicProject.groovy
+++ b/src/main/groovy/com/blackbaud/templates/project/BasicProject.groovy
@@ -265,8 +265,8 @@ performance_test {
 
             includeGradleSubmodule("${type}-client")
 
-            buildFile.appendAfterLine(/^dependencies \{/, "    compile project(\"${type}-client\")")
-            buildFile.appendBeforeLine(/sharedTest/, "    sharedTestCompile project(path: \"${type}-client\", configuration: \"mainTestRuntime\")")
+            buildFile.appendAfterLine(/^dependencies \{/, "    compile project(\":${type}-client\")")
+            buildFile.appendBeforeLine(/sharedTest/, "    sharedTestCompile project(path: \":${type}-client\", configuration: \"mainTestRuntime\")")
         }
     }
 


### PR DESCRIPTION
…rencing a subodule within another submodule which can be confusing so just always qualify

@Blackbaud-ChrisJenkins 